### PR TITLE
Remove the Cpp process requirement

### DIFF
--- a/6GEI311_Lab_4/6GEI311_Lab_4/6GEI311_Lab_4.vcxproj
+++ b/6GEI311_Lab_4/6GEI311_Lab_4/6GEI311_Lab_4.vcxproj
@@ -80,8 +80,8 @@
     <ReferencePath>$(ReferencePath)</ReferencePath>
     <TargetName>exec_time</TargetName>
     <TargetExt>.pyd</TargetExt>
-    <IncludePath>C:\Users\manon\AppData\Local\Programs\Python\Python37\include;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
-    <LibraryPath>C:\Users\manon\AppData\Local\Programs\Python\Python37\libs;$(LibraryPath)</LibraryPath>
+    <IncludePath>C:\Program Files\Python36\include;C:\Users\manon\AppData\Local\Programs\Python\Python37\include;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>C:\Program Files\Python36\libs;C:\Users\manon\AppData\Local\Programs\Python\Python37\libs;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>exec_time</TargetName>

--- a/6GEI311_Lab_4/6GEI311_Lab_4/main.cpp
+++ b/6GEI311_Lab_4/6GEI311_Lab_4/main.cpp
@@ -58,19 +58,8 @@ static PyObject* thread_exec_time(PyObject* self, PyObject* args)
 	return GetList(time_results);
 }
 
-static PyObject* process_exec_time(PyObject* self, PyObject* args)
-{
-	time_results.clear();
-	int iterations;
-	PyArg_ParseTuple(args, "i", &iterations);
-
-	PyObject *pythonVal = Py_BuildValue("");
-	return pythonVal;
-}
-
 static PyMethodDef methods[] = {
 	   { "thread_exec_time", thread_exec_time, METH_VARARGS, "Thread execution" },
-	   { "process_exec_time", process_exec_time, METH_VARARGS, "Process execution" },
 	   { "simple_loop", simple_loop, METH_VARARGS, "Simple execution"},
 	   { NULL, NULL }
 };

--- a/6GEI311_Lab_4/main.py
+++ b/6GEI311_Lab_4/main.py
@@ -19,14 +19,13 @@ def boucle(base=0):
 
 def boucle_cpp(base=0):
     start = time.time() - base
-    exec_time.boucle()
+    exec_time.simple_loop()
     stop = time.time() - base
     return start, stop
 
 
 def interface_gui():
     def visualize_runtimes(results, title):
-        print(results)
         start, stop = np.array(results).T
         props = dict(boxstyle='round', facecolor='wheat', alpha=0.5)
         fig, ax = plt.subplots()
@@ -44,11 +43,13 @@ def interface_gui():
         for i in (range(999999)):
             np.tanh(i)
         stop = time.time() - base
-        res = "Temps d'exécution : " + str(stop - start) + " secondes"
+        seconds = round(((stop - start)), 4)
+        res = "Execution time : " + str(seconds) + " secondes"
         label_time.configure(text=res)
 
     def show_simple_loop(delta):
-        res = "Temps d'exécution : " + str(delta) + " microsecondes"
+        seconds = round((delta/10000.0), 4)
+        res = "Execution time : " + str(seconds) + " seconds"
         label_time.configure(text=res)
 
     def multithreading(func, iterations, workers):
@@ -63,6 +64,7 @@ def interface_gui():
             res = executor.map(func, [begin_time for i in range(iterations)])
         return list(res)
 
+        
     window = tk.Tk()
     window.title("Les boucles d'exécution")
 
@@ -71,7 +73,7 @@ def interface_gui():
     nb_workers = tk.Spinbox(window, from_=1, to=100, font="Arial, 12")
     nb_workers.grid(column=1, row=4)
 
-    button_simpleloop_python = tk.Button(window, text="Boucle simple (python)", font="Arial, 12", bg="#e77f67",
+    button_simpleloop_python = tk.Button(window, text="Boucle simple (Python)", font="Arial, 12", bg="#e77f67",
                                          command=boucle_simple)
     button_simpleloop_python.grid(column=0, row=1)
     button_multiprocess_python = tk.Button(window, text="Boucle découpée en N processus (Python)",
@@ -90,16 +92,12 @@ def interface_gui():
     button_simpleloop_cpp = tk.Button(window, text="Boucle simple (C++)", font="Arial, 12", bg="#786fa6",
                                       command=lambda: show_simple_loop(exec_time.simple_loop()))
     button_simpleloop_cpp.grid(column=1, row=1)
-    button_multiprocess_cpp = tk.Button(window, text="Boucle découpée en N processus (C++)", font="Arial, 12",
-                                        bg="#786fa6",
-                                        command=lambda: visualize_runtimes(
-                                            exec_time.process_exec_time(int(nb_workers.get())), "C++: multiprocessing"))
-    button_multiprocess_cpp.grid(column=1, row=2)
+
     button_multithreads_cpp = tk.Button(window, text="Boucle découpée en N threads (C++)",
                                         font="Arial, 12", bg="#786fa6",
                                         command=lambda: visualize_runtimes(
                                             exec_time.thread_exec_time(int(nb_workers.get())), "C++: multithreading"))
-    button_multithreads_cpp.grid(column=1, row=3)
+    button_multithreads_cpp.grid(column=1, row=2)
 
     label_time = tk.Label(window,
                           text="Cliquez sur une des stratégies pour afficher son temps d'exécution pour 16 itérations",


### PR DESCRIPTION
Selon Alexis, nous n'avons pas besoin de gérer le temps d'execution des
process. Comme celui en Python est déjà fait, nous retirons seulement
celui en C++